### PR TITLE
Move common classes from gooddata-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.12</version>

--- a/src/main/java/com/gooddata/collections/MultiPageList.java
+++ b/src/main/java/com/gooddata/collections/MultiPageList.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.collections;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.Validate.notNull;
+
+/**
+ * Adapter over PageableList to offer easy iteration/streaming over multiple pages,
+ * lazily loading of pages using specified pageProvider.
+ */
+public class MultiPageList<T> extends PageableList<T> {
+    private final PageableList<T> delegate;
+    private final Function<Page, PageableList<T>> pageProvider;
+
+    /**
+     * To list all the pages, starting with the very first one.
+     *
+     * @param pageProvider provider used to load the pages
+     */
+    public MultiPageList(final Function<Page, PageableList<T>> pageProvider) {
+        this(new PageRequest(), pageProvider);
+    }
+
+    /**
+     * To list all the pages, starting with the startPage specified.
+     *
+     * @param startPage    page to start with
+     * @param pageProvider provider used to load the pages
+     */
+    public MultiPageList(final Page startPage, final Function<Page, PageableList<T>> pageProvider) {
+        this(notNull(pageProvider, "pageProvider can't be null").apply(startPage), pageProvider);
+    }
+
+    MultiPageList(final PageableList<T> delegate,
+                  final Function<Page, PageableList<T>> pageProvider) {
+        this.delegate = notNull(delegate, "delegate can't be null");
+        this.pageProvider = notNull(pageProvider, "pageProvider can't be null");
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new PageIterator<>(delegate, pageProvider);
+    }
+
+    /**
+     * Do not iterate over pages, get the current page items only
+     *
+     * @return the list of current page items only
+     */
+    @Override
+    public List<T> getCurrentPageItems() {
+        return delegate.getCurrentPageItems();
+    }
+
+    /**
+     * Iterate over multiple pages and collect the results to list
+     *
+     * @return list with all the results
+     */
+    @Override
+    public List<T> collectAll() {
+        return stream().collect(toList());
+    }
+
+    /**
+     * Returns description of the next page.
+     *
+     * @return next page, might be <code>null</code>
+     */
+    @Override
+    public Page getNextPage() {
+        return delegate.getNextPage();
+    }
+
+    /**
+     * Signals whether there are more subsequent pages or the last page has been reached
+     * @return true if there are more results to come
+     */
+    @Override
+    public boolean hasNextPage() {
+        return delegate.hasNextPage();
+    }
+
+    /**
+     * Returns map of links.
+     *
+     * @return map of links, might be <code>null</code>
+     */
+    @Override
+    public Map<String, String> getLinks() {
+        return delegate.getLinks();
+    }
+
+    /**
+     * Returns description of the current collection page.
+     *
+     * @return current collection page, might be <code>null</code>
+     */
+    @Override
+    public Paging getPaging() {
+        return delegate.getPaging();
+    }
+
+    /**
+     * Returns size of the items collection on a current page. If you need the size of entire collection
+     * across all pages, use <code>totalSize()</code> instead.
+     *
+     * @return size of the items collection on a current page
+     */
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    /**
+     * Returns size of entire collection across all pages. It will fetch all the pages, so use wisely.
+     * @return size of entire collection across all pages
+     */
+    public int totalSize() {
+        return (int) stream().count();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    /**
+     * Whether current page contains the specified object. If you need to verify whether entire collection
+     * across all pages contains the object, use <code>stream().anyMatch(o)</code> instead.
+     */
+    @Override
+    public boolean contains(final Object o) {
+        return delegate.contains(o);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(final T[] a) {
+        return delegate.toArray(a);
+    }
+
+    @Override
+    public boolean add(final T item) {
+        return delegate.add(item);
+    }
+
+    @Override
+    public boolean remove(final Object o) {
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(final Collection<?> c) {
+        return delegate.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends T> c) {
+        return delegate.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(final int index, final Collection<? extends T> c) {
+        return delegate.addAll(index, c);
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> c) {
+        return delegate.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public T get(final int index) {
+        return delegate.get(index);
+    }
+
+    @Override
+    public T set(final int index, final T element) {
+        return delegate.set(index, element);
+    }
+
+    @Override
+    public void add(final int index, final T element) {
+        delegate.add(index, element);
+    }
+
+    @Override
+    public T remove(final int index) {
+        return delegate.remove(index);
+    }
+
+    @Override
+    public int indexOf(final Object o) {
+        return delegate.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(final Object o) {
+        return delegate.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return delegate.listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(final int index) {
+        return delegate.listIterator(index);
+    }
+
+    @Override
+    public List<T> subList(final int fromIndex, final int toIndex) {
+        return delegate.subList(fromIndex, toIndex);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    private static final class PageIterator<T> implements Iterator<T> {
+
+        private PageableList<T> currentPage;
+        private Iterator<T> pageItemsIterator;
+        private final Function<Page, PageableList<T>> pageProvider;
+
+        PageIterator(final PageableList<T> currentPage, final Function<Page, PageableList<T>> pageProvider) {
+            this.pageProvider = pageProvider;
+            this.currentPage = currentPage;
+            this.pageItemsIterator = currentPage.getItemsIterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (pageItemsIterator.hasNext()) {
+                return true;
+            }
+
+            if (currentPage.getNextPage() == null) {
+                return false;
+            }
+
+            final PageableList<T> next = pageProvider.apply(currentPage.getNextPage());
+            if (currentPage.getNextPage().equals(next.getNextPage())) {
+                throw new IllegalStateException("page provider does not iterate properly, returns the same page");
+            }
+
+            if (next.isEmpty() && next.getNextPage() != null) {
+                throw new IllegalStateException("page has no results, yet claims there is next page");
+            }
+
+            currentPage = next;
+            pageItemsIterator = currentPage.getItemsIterator();
+
+            return pageItemsIterator.hasNext();
+        }
+
+        @Override
+        public T next() {
+            if (!pageItemsIterator.hasNext()) {
+                throw new NoSuchElementException("no more items left");
+            }
+
+            return pageItemsIterator.next();
+        }
+    }
+}

--- a/src/main/java/com/gooddata/gdc/Header.java
+++ b/src/main/java/com/gooddata/gdc/Header.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.gdc;
+
+/**
+ * Utility class containing common GoodData HTTP headers.
+ */
+public final class Header {
+
+    public static final String GDC_REQUEST_ID = "X-GDC-REQUEST";
+
+    private Header() {
+        throw new AssertionError("This class is not supposed to be instantiated");
+    }
+}

--- a/src/test/groovy/com/gooddata/collections/MultiPageListTest.groovy
+++ b/src/test/groovy/com/gooddata/collections/MultiPageListTest.groovy
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.collections
+
+import spock.lang.Specification
+
+class MultiPageListTest extends Specification {
+
+    final MultiPageList<Integer> singlePageList = new MultiPageList<>(
+            new PageableList<>([11], null),
+            {page -> null}
+    )
+
+    final MultiPageList<Integer> twoPageList = new MultiPageList<>(
+            new PageableList<>([11], new Paging("nextpage2")),
+            {page -> new PageableList<>([12], null)}
+    )
+
+    final PageableList delegate = Mock(PageableList)
+
+    def "test size"() {
+        expect:
+        singlePageList.totalSize() == 1
+        twoPageList.totalSize() == 2
+    }
+
+    def "test getCurrentPageItems"() {
+        expect:
+        singlePageList.getCurrentPageItems() == [11]
+        twoPageList.getCurrentPageItems() == [11]
+    }
+
+    def "test collectAll"() {
+        expect:
+        singlePageList.collectAll() == [11]
+        twoPageList.collectAll() == [11, 12]
+    }
+
+    def "test isEmpty"() {
+        when:
+        MultiPageList<Integer> empty = new MultiPageList<Integer>({page -> new PageableList<>()})
+
+        then:
+        empty.isEmpty()
+        !singlePageList.isEmpty()
+        !twoPageList.isEmpty()
+    }
+
+    def "test iterator"() {
+        when:
+        final Iterator<Integer> iterator = new MultiPageList<>(
+                new PageableList<>([1], null),
+                {page -> null}
+        ).iterator()
+
+        then:
+        iterator.hasNext()
+        iterator.next() == 1
+        !iterator.hasNext()
+
+        when:
+        iterator.next()
+
+        then:
+        NoSuchElementException exc = thrown()
+        exc.message ==~ /.*no more items left.*/
+    }
+
+    def "test iterator with PageProvider"() {
+        when:
+        final PageableList<Integer> lastPage = new PageableList<>([3], null)
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>([1, 2], new Paging("next")),
+                {page -> lastPage}
+        )
+
+        then:
+        final Iterator<Integer> iterator = list.iterator()
+        iterator.hasNext()
+        iterator.next() == 1
+        iterator.hasNext()
+        iterator.next() == 2
+        iterator.hasNext()
+        iterator.next() == 3
+
+        !iterator.hasNext()
+
+        when:
+        iterator.next()
+
+        then:
+        NoSuchElementException exc = thrown()
+        exc.message ==~ /.*no more items left.*/
+    }
+
+    def "test stream"() {
+        when:
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>([1, 2], null),
+                {page -> null}
+        )
+
+        then:
+        list.max() == 2
+    }
+
+    def "test stream with PageProvider"() {
+        when:
+        final PageableList<Integer> lastPage = new PageableList<>([3], null)
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>([1, 2], new Paging("next")),
+                {page -> lastPage}
+        )
+
+        then:
+        list.max() == 3
+    }
+
+    def "test infinite loop should be prevented"() {
+        given:
+        final PageableList<Integer> pageableList = new PageableList<>([1, 2], new Paging("next"))
+        final PageableList<Integer> list = new MultiPageList<>(
+                pageableList,
+                {page -> pageableList}
+        )
+
+        when:
+        list.forEach({})
+
+        then:
+        IllegalStateException exc = thrown()
+        exc.message ==~ /.*page provider does not iterate properly, returns the same page.*/
+    }
+
+    def "should fail on misbehaving next page"() {
+        given:
+        final PageableList<Integer> pageableList = new PageableList<>([1, 2], new Paging("next"))
+        final PageableList<Integer> misbehaving = Mock(PageableList)
+        misbehaving.isEmpty() >> true
+        misbehaving.getNextPage() >> new PageRequest()
+
+        final PageableList<Integer> list = new MultiPageList<>(
+                pageableList,
+                {page -> misbehaving}
+        )
+
+        when:
+        list.forEach({})
+
+        then:
+        IllegalStateException exc = thrown()
+        exc.message ==~ /.*page has no results, yet claims there is next page.*/
+    }
+
+    def "test hasNext should only switch page once and only once"() {
+        when:
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>([], new Paging("page2")),
+                new SinglePageProvider(new PageableList<>([2], new Paging("page3")))
+        )
+        final Iterator<Integer> iterator = list.iterator()
+
+        then:
+        iterator.hasNext()
+        iterator.hasNext()
+
+        iterator.next() == 2
+
+        when:
+        iterator.hasNext()
+
+        then:
+        IllegalStateException exc = thrown()
+        exc.message ==~ /.*second page has been requested.*/
+    }
+
+    def "test delegate methods"() {
+        when:
+        final MultiPageList<String> list = new MultiPageList<String>(delegate, {page -> null})
+        list.getNextPage()
+        list.hasNextPage()
+        list.getLinks()
+        list.getPaging()
+        list.size()
+        list.contains("x")
+        list.toArray()
+        list.toArray(["x"])
+        list.add("a")
+        list.add(1, "a")
+        list.remove(0)
+        list.remove("b")
+        list.clear()
+        list.containsAll(["a", "b"])
+        list.addAll(["a", "b"])
+        list.addAll(1, ["a", "b"])
+        list.removeAll(["a", "b"])
+        list.retainAll(["a", "b"])
+        list.set(0, "x")
+        list.get(0)
+        list.indexOf("x")
+        list.lastIndexOf("x")
+        list.listIterator()
+        list.listIterator(1)
+        list.subList(0, 1)
+
+        then:
+        1 * delegate.getNextPage()
+        1 * delegate.hasNextPage()
+        1 * delegate.getLinks()
+        1 * delegate.getPaging()
+        1 * delegate.size()
+        1 * delegate.contains("x")
+        1 * delegate.toArray()
+        1 * delegate.toArray(["x"])
+        1 * delegate.add("a")
+        1 * delegate.add(1, "a")
+        1 * delegate.remove(0)
+        1 * delegate.remove("b")
+        1 * delegate.clear()
+        1 * delegate.containsAll(["a", "b"])
+        1 * delegate.addAll(["a", "b"])
+        1 * delegate.addAll(1, ["a", "b"])
+        1 * delegate.removeAll(["a", "b"])
+        1 * delegate.retainAll(["a", "b"])
+        1 * delegate.set(0, "x")
+        1 * delegate.get(0)
+        1 * delegate.indexOf("x")
+        1 * delegate.lastIndexOf("x")
+        1 * delegate.listIterator()
+        1 * delegate.listIterator(1)
+        1 * delegate.subList(0, 1)
+    }
+}

--- a/src/test/groovy/com/gooddata/collections/SinglePageProvider.java
+++ b/src/test/groovy/com/gooddata/collections/SinglePageProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+
+package com.gooddata.collections;
+
+import java.util.function.Function;
+
+/**
+ * This provider will only provide one page, but will throw an exception when asked to provide another
+ */
+class SinglePageProvider implements Function<Page, PageableList<Integer>> {
+    int count = 0;
+    final PageableList<Integer> page;
+
+    SinglePageProvider(final PageableList<Integer> page) {
+        this.page = page;
+    }
+
+    @Override
+    public PageableList<Integer> apply(final Page page) {
+        count++;
+        if(count > 1) {
+            throw new IllegalStateException("second page has been requested");
+        }
+
+        return this.page;
+    }
+}
+


### PR DESCRIPTION
Paging and request ID header are used across GoodData REST libraries
and should be therefore shared in common artifact.