### PR TITLE
Move Joda DateTime compatible formatter to interface

### DIFF
--- a/src/main/java/com/gooddata/util/ISOZonedDateTime.java
+++ b/src/main/java/com/gooddata/util/ISOZonedDateTime.java
@@ -9,7 +9,13 @@ import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -18,4 +24,15 @@ import java.lang.annotation.*;
 @JsonDeserialize(using = ISOZonedDateTimeDeserializer.class)
 @Documented
 public @interface ISOZonedDateTime {
+
+    /**
+     * Used Offset 'X' will output 'Z' when the offset to be output would be zero.
+     * @see DateTimeFormatter
+     */
+    String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+
+    /**
+     * Formatter compatible with original joda-time {@link org.joda.time.format.ISODateTimeFormat}
+     */
+    DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withZone(ZoneOffset.UTC);
 }

--- a/src/main/java/com/gooddata/util/ISOZonedDateTimeSerializer.java
+++ b/src/main/java/com/gooddata/util/ISOZonedDateTimeSerializer.java
@@ -11,21 +11,13 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
+
+import static com.gooddata.util.ISOZonedDateTime.FORMATTER;
 
 /**
- * Serializes JSR 310 {@link ZonedDateTime} fields to the ISO date time format in the UTC timezone ({@value ISOZonedDateTimeSerializer#DATE_TIME_PATTERN}).
+ * Serializes JSR 310 {@link ZonedDateTime} fields to the ISO date time format in the UTC timezone ({@value ISOZonedDateTime#DATE_TIME_PATTERN}).
  */
 public class ISOZonedDateTimeSerializer extends JsonSerializer<ZonedDateTime> {
-
-    /**
-     * Used Offset 'X' will output 'Z' when the offset to be output would be zero.
-     * @see DateTimeFormatter
-     */
-    public static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
-
-    static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withZone(ZoneOffset.UTC);
 
     @Override
     public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider __) throws IOException {


### PR DESCRIPTION
This pattern is compatible with original Joda ISODateTimeFormat, so is useful in places where conversion is needed. Move it to interface for easier usage. Make formatter public to be able to use it from all necessary places.