### PR TITLE
Make the spring-web dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 branches:
   only:
      - master
+     - /\d\.0\.0-RC/
 cache:
   directories:
     - '$HOME/.m2/repository'

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,8 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${spring.version}</version>
+            <!-- this dependency is only needed when using SpringMutableUri for paging -->
+            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>aopalliance</groupId>

--- a/src/main/java/com/gooddata/sdk/common/collections/CustomPageRequest.java
+++ b/src/main/java/com/gooddata/sdk/common/collections/CustomPageRequest.java
@@ -6,6 +6,7 @@
 package com.gooddata.sdk.common.collections;
 
 import com.gooddata.sdk.common.util.GoodDataToStringBuilder;
+import com.gooddata.sdk.common.util.MutableUri;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -96,19 +97,18 @@ public class CustomPageRequest implements PageRequest {
     }
 
     @Override
-    public URI getPageUri(final UriComponentsBuilder uriBuilder) {
-        notNull(uriBuilder, "uriBuilder");
-        final UriComponentsBuilder copy = UriComponentsBuilder.fromUriString(uriBuilder.build().toUriString());
-        return updateWithPageParams(copy).build().toUri();
+    public URI getPageUri(final MutableUri mutableUri) {
+        notNull(mutableUri, "mutableUri");
+        return updateWithPageParams(mutableUri.copy()).toUri();
     }
 
     @Override
-    public UriComponentsBuilder updateWithPageParams(final UriComponentsBuilder uriBuilder) {
+    public MutableUri updateWithPageParams(final MutableUri mutableUri) {
         if (offset != null) {
-            uriBuilder.replaceQueryParam("offset", offset);
+            mutableUri.replaceQueryParam("offset", offset);
         }
-        uriBuilder.replaceQueryParam("limit", limit);
-        return uriBuilder;
+        mutableUri.replaceQueryParam("limit", limit);
+        return mutableUri;
     }
 
     @Override

--- a/src/main/java/com/gooddata/sdk/common/collections/PageRequest.java
+++ b/src/main/java/com/gooddata/sdk/common/collections/PageRequest.java
@@ -5,6 +5,7 @@
  */
 package com.gooddata.sdk.common.collections;
 
+import com.gooddata.sdk.common.util.MutableUri;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -18,18 +19,18 @@ public interface PageRequest {
     /**
      * Creates {@link URI} for this page request.
      * <p>
-     * Use {@link #updateWithPageParams(UriComponentsBuilder)} if you have URI template and only want to update it with
+     * Use {@link #updateWithPageParams(MutableUri)} if you have URI template and only want to update it with
      * page query params.
      *
-     * @param uriBuilder URI builder used for generating page URI
+     * @param mutableUri mutable URI used for generating page URI
      * @return compiled page URI
      */
-    URI getPageUri(final UriComponentsBuilder uriBuilder);
+    URI getPageUri(final MutableUri mutableUri);
 
     /**
-     * Updates provided URI builder query params according to this page configuration.
+     * Updates provided mutable URI query params according to this page configuration.
      * <p>
-     * As {@link #getPageUri(UriComponentsBuilder)} returns expanded page URI it is not very useful for cases that
+     * As {@link #getPageUri(MutableUri)} returns expanded page URI it is not very useful for cases that
      * require use of URI template with URI variables. This method allows you to use URI templates and benefit
      * from pagination support implemented in {@link PageRequest} implementations. It is especially useful if you need to handle
      * multiple requests of the same URI template in the same way - e.g. monitor request made by {@link RestOperations}
@@ -39,11 +40,11 @@ public interface PageRequest {
      * This method is useful when you have URI template with placeholders and only want to add query parameters based
      * on this page to it.
      * <p>
-     * Use {@link #getPageUri(UriComponentsBuilder)} if you want to get concrete page URI and don't have URI template.
+     * Use {@link #getPageUri(MutableUri)} if you want to get specific page URI and don't have URI template.
      *
-     * @param uriBuilder URI builder used for constructing page URI
-     * @return provided and updated builder instance
+     * @param mutableUri URI builder used for constructing page URI
+     * @return provided and updated mutable URI instance
      * @see RestOperations
      */
-    UriComponentsBuilder updateWithPageParams(final UriComponentsBuilder uriBuilder);
+    MutableUri updateWithPageParams(final MutableUri mutableUri);
 }

--- a/src/main/java/com/gooddata/sdk/common/collections/UriPageRequest.java
+++ b/src/main/java/com/gooddata/sdk/common/collections/UriPageRequest.java
@@ -6,6 +6,7 @@
 package com.gooddata.sdk.common.collections;
 
 import com.gooddata.sdk.common.util.GoodDataToStringBuilder;
+import com.gooddata.sdk.common.util.MutableUri;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
@@ -40,11 +41,11 @@ class UriPageRequest implements PageRequest {
     /**
      * This is effectively no-op. Returns internal URI provided by REST API.
      *
-     * @param uriBuilder not used internally, can be null
+     * @param mutableUri not used internally, can be null
      * @return next page URI provided by REST API
      */
     @Override
-    public URI getPageUri(final UriComponentsBuilder uriBuilder) {
+    public URI getPageUri(final MutableUri mutableUri) {
         return pageUri.toUri();
     }
 
@@ -52,16 +53,16 @@ class UriPageRequest implements PageRequest {
      * {@inheritDoc}
      * <p>
      * Note that by using this method you might end up with URI that will be different from the one returned by
-     * {@link #getPageUri(UriComponentsBuilder)}. Method only copies query parameters and does not care about
+     * {@link #getPageUri(MutableUri)}. Method only copies query parameters and does not care about
      * URI path.
      */
     @Override
-    public UriComponentsBuilder updateWithPageParams(final UriComponentsBuilder uriBuilder) {
-        notNull(uriBuilder, "uriBuilder");
+    public MutableUri updateWithPageParams(final MutableUri mutableUri) {
+        notNull(mutableUri, "mutableUri");
         for (Entry<String, List<String>> entry : pageUri.getQueryParams().entrySet()) {
-            uriBuilder.replaceQueryParam(entry.getKey(), entry.getValue().toArray());
+            mutableUri.replaceQueryParam(entry.getKey(), entry.getValue().toArray());
         }
-        return uriBuilder;
+        return mutableUri;
     }
 
     @Override

--- a/src/main/java/com/gooddata/sdk/common/util/MutableUri.java
+++ b/src/main/java/com/gooddata/sdk/common/util/MutableUri.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2007-2020, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.sdk.common.util;
+
+import java.net.URI;
+
+/**
+ * Mutable form of URI. Provides simple abstraction to separate the URI mutation logic. The default implemntation
+ * {@link SpringMutableUri} uses spring-web library which is otherwise not needed when using gooddata-rest-common ie.
+ * only for model classes.
+ */
+public interface MutableUri {
+
+    /**
+     * Copies this instance.
+     * @return copy this instance
+     */
+    MutableUri copy();
+
+    /**
+     * Replaces the query param of given name with given values.
+     *
+     * @param name query param name
+     * @param values query param values
+     */
+    void replaceQueryParam(final String name, final Object... values);
+
+    /**
+     * URI created from current state of this instance.
+     * @return uri
+     */
+    URI toUri();
+
+    /**
+     * String representation of URI created from current state of this instance.
+     * @return uri as string
+     */
+    String toUriString();
+}

--- a/src/main/java/com/gooddata/sdk/common/util/SpringMutableUri.java
+++ b/src/main/java/com/gooddata/sdk/common/util/SpringMutableUri.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2007-2020, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.sdk.common.util;
+
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Objects;
+
+import static com.gooddata.sdk.common.util.Validate.notNull;
+
+/**
+ * Spring framework based implementation of {@link MutableUri}. Works as wrapper for spring's {@link UriComponentsBuilder}.
+ * To use this class you need to explicitly declare spring-web dependency.
+ */
+public class SpringMutableUri implements MutableUri {
+
+    private final UriComponentsBuilder builder;
+
+    /**
+     * New instance from given uri
+     * @param uri uri to wrap
+     */
+    public SpringMutableUri(final URI uri) {
+        this(UriComponentsBuilder.fromUri(uri));
+    }
+
+    /**
+     * New instance from given uri string
+     * @param uriString uri to wrap
+     */
+    public SpringMutableUri(final String uriString) {
+        this(UriComponentsBuilder.fromUriString(uriString));
+    }
+
+    private SpringMutableUri(final UriComponentsBuilder builder) {
+        this.builder = notNull(builder, "builder");
+    }
+
+    @Override
+    public MutableUri copy() {
+        final UriComponentsBuilder copy = UriComponentsBuilder.fromUriString(builder.build().toUriString());
+        return new SpringMutableUri(copy);
+    }
+
+    @Override
+    public void replaceQueryParam(final String name, final Object... values) {
+        builder.replaceQueryParam(name, values);
+    }
+
+    @Override
+    public URI toUri() {
+        return getUriComponents().toUri();
+    }
+
+    @Override
+    public String toUriString() {
+        return getUriComponents().toUriString();
+    }
+
+    /**
+     * Uri components representing the current state. The difference from {@link #toUri()} and {@link #toUriString()} is
+     * that {@link UriComponents} don't have possibly templated uri resolved.
+     * @return uri components
+     */
+    public UriComponents getUriComponents() {
+        return builder.build();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpringMutableUri that = (SpringMutableUri) o;
+        return Objects.equals(builder, that.builder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(builder);
+    }
+}

--- a/src/test/groovy/com/gooddata/sdk/common/collections/CustomPageRequestTest.groovy
+++ b/src/test/groovy/com/gooddata/sdk/common/collections/CustomPageRequestTest.groovy
@@ -5,9 +5,10 @@
  */
 package com.gooddata.sdk.common.collections
 
+import com.gooddata.sdk.common.util.MutableUri
+import com.gooddata.sdk.common.util.SpringMutableUri
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
-import org.springframework.web.util.UriComponentsBuilder
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -35,7 +36,7 @@ class CustomPageRequestTest extends Specification {
     @Unroll
     def "should getPageUri with #type"() {
         when:
-        URI pageUri = pageRequest.getPageUri(UriComponentsBuilder.fromUriString('test_uri'))
+        URI pageUri = pageRequest.getPageUri(new SpringMutableUri('test_uri'))
 
         then:
         pageUri?.toString() == expected
@@ -50,18 +51,18 @@ class CustomPageRequestTest extends Specification {
     @Unroll
     def "should updateWithPageParams with #type offset"() {
         given:
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString('test_uri/{test}')
+        MutableUri mutableUri = new SpringMutableUri('test_uri/{test}')
         CustomPageRequest pageRequest = new CustomPageRequest(offset, 10)
 
         when:
-        UriComponentsBuilder updatedBuilder = pageRequest.updateWithPageParams(uriBuilder)
-        String pageUri = updatedBuilder.build().toUriString()
+        MutableUri updatedMutableUri = pageRequest.updateWithPageParams(mutableUri)
+        String pageUri = updatedMutableUri.toUriString()
 
         then:
         pageUri == 'test_uri/{test}?offset=12&limit=10'
 
         and: "is idempotent operation"
-        pageRequest.updateWithPageParams(updatedBuilder).build().toString() == pageUri
+        pageRequest.updateWithPageParams(updatedMutableUri).toUriString() == pageUri
 
         where:
         type     | offset

--- a/src/test/groovy/com/gooddata/sdk/common/collections/UriPageRequestTest.groovy
+++ b/src/test/groovy/com/gooddata/sdk/common/collections/UriPageRequestTest.groovy
@@ -5,14 +5,14 @@
  */
 package com.gooddata.sdk.common.collections
 
+
+import com.gooddata.sdk.common.util.SpringMutableUri
 import nl.jqno.equalsverifier.EqualsVerifier
 import org.springframework.web.util.UriComponents
-import org.springframework.web.util.UriComponentsBuilder
 import spock.lang.Specification
 
 import static org.hamcrest.CoreMatchers.is
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.springframework.web.util.UriComponentsBuilder.fromUriString
 
 class UriPageRequestTest extends Specification {
 
@@ -37,11 +37,12 @@ class UriPageRequestTest extends Specification {
     def "should updateWithPageParams"() {
         given:
         UriPageRequest uri = new UriPageRequest('uri?offset=god&limit=10')
-        UriComponentsBuilder builder = fromUriString('/this/is/{template}').query('other=false')
+        SpringMutableUri mutableUri = new SpringMutableUri('/this/is/{template}')
+        mutableUri.replaceQueryParam('other', false)
 
         when:
-        uri.updateWithPageParams(builder)
-        UriComponents components = builder.build()
+        uri.updateWithPageParams(mutableUri)
+        UriComponents components = mutableUri.getUriComponents()
 
         then:
         components
@@ -49,11 +50,11 @@ class UriPageRequestTest extends Specification {
         components.queryParams == ['other': ['false'], 'offset': ['god'], 'limit': ['10']]
 
         and: "is idempotent operation"
-        uri.updateWithPageParams(builder)
-        uri.updateWithPageParams(builder)
+        uri.updateWithPageParams(mutableUri)
+        uri.updateWithPageParams(mutableUri)
 
         then:
-        builder.build() == components
+        mutableUri.getUriComponents() == components
     }
 
     def "should not double encode"() {

--- a/src/test/groovy/com/gooddata/sdk/common/util/SpringMutableUriTest.groovy
+++ b/src/test/groovy/com/gooddata/sdk/common/util/SpringMutableUriTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2007-2020, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.sdk.common.util
+
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import spock.lang.Specification
+
+class SpringMutableUriTest extends Specification {
+
+    def "should copy"() {
+        given:
+        def original = new SpringMutableUri('/some/uri?p=val')
+
+        when:
+        def copy = original.copy()
+
+        then:
+        copy instanceof SpringMutableUri
+        (copy as SpringMutableUri).getUriComponents() == original.getUriComponents()
+
+        and:
+        copy.replaceQueryParam('p', 'val2')
+
+        then:
+        original.toUriString() == '/some/uri?p=val'
+    }
+
+    def "should replace query param"() {
+        given:
+        def mutableUri = new SpringMutableUri(URI.create('/some/uri?p=val'))
+
+        when:
+        mutableUri.replaceQueryParam('p', 'a', 2)
+
+        then:
+        mutableUri.toUri() == URI.create('/some/uri?p=a&p=2')
+    }
+
+    def "should verify equals"() {
+        expect:
+        EqualsVerifier.forClass(SpringMutableUri)
+                .usingGetClass()
+                .verify()
+    }
+}


### PR DESCRIPTION
The only UriComponentsBuilder class used from spring-web was used in
methods called from gooddata-java's service module. Wrapping it to
the extra intrface allows to use this library in model module without
spring-web.